### PR TITLE
Deploy pdf to github from tectronic docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,21 @@
-# We test each method for building LaTeX in a separate job.
-jobs:
-  include:
-    # Each script call is a separate job.
-    - stage: tectonic-docker
-      language: generic
-      sudo: required
-      services: docker
-      script: chmod +x $TRAVIS_BUILD_DIR/test/compile-1a.sh && $TRAVIS_BUILD_DIR/test/compile-1a.sh
-    - stage: tectonic-miniconda
-      language: generic
-      script: chmod +x $TRAVIS_BUILD_DIR/test/compile-1.sh && $TRAVIS_BUILD_DIR/test/compile-1.sh
-      cache:
-        directories:
-          - $HOME/miniconda
-          - $HOME/.cache/Tectonic
-    - stage: texlive-pdflatex
-      language: generic
-      script: chmod +x $TRAVIS_BUILD_DIR/test/compile-2.sh && $TRAVIS_BUILD_DIR/test/compile-2.sh
-      cache:
-        directories:
-          - /tmp/texlive
-          - $HOME/.texlive
-    - stage: tinytex
-      language: r
-      sudo: true
-      latex: false
-      pandoc: false
-      warnings_are_errors: false
-      install: echo "The install step is required but does nothing now."
-      script: chmod +x $TRAVIS_BUILD_DIR/test/compile-3.sh && $TRAVIS_BUILD_DIR/test/compile-3.sh
-      cache:
-        directories:
-          - packages
-          - /tmp/texlive
-          - $HOME/.texlive
-          - $HOME/.TinyTex
+sudo: required
+
+language: generic
+services: docker
+
+script:
+# We use the docker image from https://hub.docker.com/r/rekka/tectonic/
+- docker pull rekka/tectonic
+# interactively:
+# docker run -it --mount src=`pwd`,target=/usr/src/tex,type=bind rekka/tectonic
+- docker run --mount src=$TRAVIS_BUILD_DIR/src,target=/usr/src/tex,type=bind rekka/tectonic tectonic main.tex
+deploy:
+  provider: releases
+  api_key:
+    secure: GK0T9i6YKZlKmxurW4B8lkBGCfUcehODrWA8VcuUaK4CgSYaVj2BzMJj4E7pA3Ucm76bGR9l1yWYA+RHRwg0033A8Tw54hIinAcwiuXCpRwgcVkbbxK77o8Q4g0ooRPAMePtkQrjeq1JgHN2sZUZ2CixhtCDApM8H4yaQW7bb7TmBFut/9YEfiJVBCAE0ZNjbjXSbYADRc9Zh1fy/53xJzgKC57dQnFDrnEsGlwRkrv5lQK+3Dw7ktd48pQe8C3c2LNZn052gaR0TxxzDBAyvG4nmeA17wYMvZk7UhfKYVdqUjNqwyjktvWQQDOAtWL7OrlBNfWyf5bEn1RsfsnZ7lX/3uTj1z2fQeaYcx29goSo6y7cemz+UFsuoG3ggMuD1V81xkLI82WglYnbDEd7wij5kj1+/YAliiiZtO98kLUXbyPKWq0ycmPjj1PKyiX1Gk4LMtPfvDEIdhm/uShCY+6PrOxnGPAEd+gKgA8kAdhkuZ1/IZjkbz0dQpoZgJse7V71x+cop8fvHsuFUcj/irk4qzfVkfhnKuNpMtq2z6HDvQ/GDkZKUTkNaok8rWGFGhE8TiXCoaEoWUASEQcqouQY8KHjqQT6JVgKLwsoPuA34Pb5Fb6tbFzrNT5QE7GTeoVa9GPXJ3IrKepdcRAo3I8GVEyH0rWItdWBH0tU7fo=
+  file:
+  - ./src/main.pdf
+  skip_cleanup: true
+  on:
+    tags: true
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,3 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,37 @@
-sudo: required
-
-language: generic
-services: docker
-
-script:
-# We use the docker image from https://hub.docker.com/r/rekka/tectonic/
-- docker pull rekka/tectonic
-# interactively:
-# docker run -it --mount src=`pwd`,target=/usr/src/tex,type=bind rekka/tectonic
-- docker run --mount src=$TRAVIS_BUILD_DIR/src,target=/usr/src/tex,type=bind rekka/tectonic tectonic main.tex
-deploy:
-  provider: releases
-  api_key:
-    secure: GK0T9i6YKZlKmxurW4B8lkBGCfUcehODrWA8VcuUaK4CgSYaVj2BzMJj4E7pA3Ucm76bGR9l1yWYA+RHRwg0033A8Tw54hIinAcwiuXCpRwgcVkbbxK77o8Q4g0ooRPAMePtkQrjeq1JgHN2sZUZ2CixhtCDApM8H4yaQW7bb7TmBFut/9YEfiJVBCAE0ZNjbjXSbYADRc9Zh1fy/53xJzgKC57dQnFDrnEsGlwRkrv5lQK+3Dw7ktd48pQe8C3c2LNZn052gaR0TxxzDBAyvG4nmeA17wYMvZk7UhfKYVdqUjNqwyjktvWQQDOAtWL7OrlBNfWyf5bEn1RsfsnZ7lX/3uTj1z2fQeaYcx29goSo6y7cemz+UFsuoG3ggMuD1V81xkLI82WglYnbDEd7wij5kj1+/YAliiiZtO98kLUXbyPKWq0ycmPjj1PKyiX1Gk4LMtPfvDEIdhm/uShCY+6PrOxnGPAEd+gKgA8kAdhkuZ1/IZjkbz0dQpoZgJse7V71x+cop8fvHsuFUcj/irk4qzfVkfhnKuNpMtq2z6HDvQ/GDkZKUTkNaok8rWGFGhE8TiXCoaEoWUASEQcqouQY8KHjqQT6JVgKLwsoPuA34Pb5Fb6tbFzrNT5QE7GTeoVa9GPXJ3IrKepdcRAo3I8GVEyH0rWItdWBH0tU7fo=
-  file:
-  - ./src/main.pdf
-  skip_cleanup: true
-  on:
-    tags: true
+# We test each method for building LaTeX in a separate job.
+jobs:
+  include:
+    # Each script call is a separate job.
+    - stage: tectonic-docker
+      language: generic
+      sudo: required
+      services: docker
+      script: chmod +x $TRAVIS_BUILD_DIR/test/compile-1a.sh && $TRAVIS_BUILD_DIR/test/compile-1a.sh
+    - stage: tectonic-miniconda
+      language: generic
+      script: chmod +x $TRAVIS_BUILD_DIR/test/compile-1.sh && $TRAVIS_BUILD_DIR/test/compile-1.sh
+      cache:
+        directories:
+          - $HOME/miniconda
+          - $HOME/.cache/Tectonic
+    - stage: texlive-pdflatex
+      language: generic
+      script: chmod +x $TRAVIS_BUILD_DIR/test/compile-2.sh && $TRAVIS_BUILD_DIR/test/compile-2.sh
+      cache:
+        directories:
+          - /tmp/texlive
+          - $HOME/.texlive
+    - stage: tinytex
+      language: r
+      sudo: true
+      latex: false
+      pandoc: false
+      warnings_are_errors: false
+      install: echo "The install step is required but does nothing now."
+      script: chmod +x $TRAVIS_BUILD_DIR/test/compile-3.sh && $TRAVIS_BUILD_DIR/test/compile-3.sh
+      cache:
+        directories:
+          - packages
+          - /tmp/texlive
+          - $HOME/.texlive
+          - $HOME/.TinyTex

--- a/1a-tectonic-docker/.travis.yml
+++ b/1a-tectonic-docker/.travis.yml
@@ -9,3 +9,13 @@ script:
   # interactively:
   # docker run -it --mount src=`pwd`,target=/usr/src/tex,type=bind rekka/tectonic
   - docker run --mount src=$TRAVIS_BUILD_DIR/src,target=/usr/src/tex,type=bind rekka/tectonic tectonic main.tex
+deploy:
+  provider: releases
+  api_key:
+    secure: GK0T9i6YKZlKmxurW4B8lkBGCfUcehODrWA8VcuUaK4CgSYaVj2BzMJj4E7pA3Ucm76bGR9l1yWYA+RHRwg0033A8Tw54hIinAcwiuXCpRwgcVkbbxK77o8Q4g0ooRPAMePtkQrjeq1JgHN2sZUZ2CixhtCDApM8H4yaQW7bb7TmBFut/9YEfiJVBCAE0ZNjbjXSbYADRc9Zh1fy/53xJzgKC57dQnFDrnEsGlwRkrv5lQK+3Dw7ktd48pQe8C3c2LNZn052gaR0TxxzDBAyvG4nmeA17wYMvZk7UhfKYVdqUjNqwyjktvWQQDOAtWL7OrlBNfWyf5bEn1RsfsnZ7lX/3uTj1z2fQeaYcx29goSo6y7cemz+UFsuoG3ggMuD1V81xkLI82WglYnbDEd7wij5kj1+/YAliiiZtO98kLUXbyPKWq0ycmPjj1PKyiX1Gk4LMtPfvDEIdhm/uShCY+6PrOxnGPAEd+gKgA8kAdhkuZ1/IZjkbz0dQpoZgJse7V71x+cop8fvHsuFUcj/irk4qzfVkfhnKuNpMtq2z6HDvQ/GDkZKUTkNaok8rWGFGhE8TiXCoaEoWUASEQcqouQY8KHjqQT6JVgKLwsoPuA34Pb5Fb6tbFzrNT5QE7GTeoVa9GPXJ3IrKepdcRAo3I8GVEyH0rWItdWBH0tU7fo=
+  file:
+  - ./src/main.pdf
+  skip_cleanup: true
+  on:
+    tags: true
+branch: master  

--- a/1a-tectonic-docker/.travis.yml
+++ b/1a-tectonic-docker/.travis.yml
@@ -18,4 +18,4 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-branch: master  
+    branch: master

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Want this? Instructions [below](#tinytex).
 * Now you should be in Personal settings | Applications | Travis CI | Configure and you can allow access to repositories, either select repos or all repos.
 * Copy `1a-tectonic-docker/.travis.yml` and specify the right tex file in the last line. If your tex file is not in the `src/` folder, you also need to change the path in that line after `$TRAVIS_BUILD_DIR`.
 * Commit and push, you can view your repositories at [travis-ci.com](https://travis-ci.com/).
+* For deploying to GitHub releases, see the notes [below](#deploy).
 
 ## <a name="tectonic">Instructions for building with Miniconda and Tectonic</a>
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Docker provides the ability to download a pre-installed Tectonic and then run it
 
 
 #### Con:
-* No option (yet) to automatically deploy pdfs to GitHub
 * Doesn't work with biber (yet, though it could be made to do it)
 
 Build time example file: one minute


### PR DESCRIPTION
As I red through your list (thanks for making it), I saw that you wrote its not possible (yet) to upload the pdf using the tectronic docker image. 

Since I use that setup (so far) I wanted to fix that. 

I hope the build works on your site, I did test by changing the api key to my travis in another branch, but you never know. *fingers-crossed*

I reused your api key from the other .travis.yml. However you probably need to test the integration by creating a tag.