### PR TITLE
Modification to see the list of necessary packages in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ jobs:
         - cp -a $TRAVIS_BUILD_DIR/src/fonts/. $HOME/.fonts/
         - fc-cache -f -v
       script: travis_retry chmod +x $TRAVIS_BUILD_DIR/test/texlive-test.sh && $TRAVIS_BUILD_DIR/test/texlive-test.sh
+      after_script:
+        - export PATH=/tmp/texlive/bin/x86_64-linux:$PATH
+        - tlmgr list --only-installed | grep -oP 'i \K.+?(?=:)'
       name: "Run texlive-test"
 cache:
   directories:

--- a/4-texlive/.travis.yml
+++ b/4-texlive/.travis.yml
@@ -2,19 +2,23 @@ language: generic
 
 dist: bionic
 
-## Uncomment the following lines if you use minted package or custom fonts or latex>dvips>ps2pdf
+## Uncomment the following lines if you require extra dependencies
 #before_install:
-# - sudo apt-get install ghostscript
-# - sudo apt-get install python-pygments
+# - sudo apt-get install ghostscript # If you use latex > dvips > ps2pdf
+# - sudo apt-get install python-pygments # If you use the minted package
+  # If you use custom fonts:
 # - mkdir $HOME/.fonts
 # - cp -a $TRAVIS_BUILD_DIR/src/fonts/. $HOME/.fonts/
 # - fc-cache -f -v
+
 install:
   - source ./texlive/texlive_install.sh
+
 cache:
   directories:
     - /tmp/texlive
     - $HOME/.texlive
+
 # Change working directory so including files will work
 before_script: cd $TRAVIS_BUILD_DIR/src/
 script:

--- a/4-texlive/.travis.yml
+++ b/4-texlive/.travis.yml
@@ -2,8 +2,9 @@ language: generic
 
 dist: bionic
 
-## Uncomment the following lines if you use minted package or custom fonts
+## Uncomment the following lines if you use minted package or custom fonts or latex>dvips>ps2pdf
 #before_install:
+# - sudo apt-get install ghostscript
 # - sudo apt-get install python-pygments
 # - mkdir $HOME/.fonts
 # - cp -a $TRAVIS_BUILD_DIR/src/fonts/. $HOME/.fonts/
@@ -30,3 +31,8 @@ script:
 
   # You can also pass arguments to texliveonfly:
 #  - texliveonfly --arguments='-shell-escape' main.tex
+
+## Uncomment the following lines to see the packages installed in travis
+#after_script:
+#  - export PATH=/tmp/texlive/bin/x86_64-linux:$PATH
+#  - tlmgr list --only-installed | grep -oP 'i \K.+?(?=:)'

--- a/4-texlive/texlive/texlive_install.sh
+++ b/4-texlive/texlive/texlive_install.sh
@@ -23,9 +23,8 @@ fi
 # Just including texlua so the cache check above works
 tlmgr install luatex
 
-# We need to change the working directory before including a file
-cd "$(dirname "${BASH_SOURCE[0]}")"
-tlmgr install $(cat texlive_packages | grep -v -e '^[[:space:]]*$' -e '^#')
+# We specify the directory in which it is located texlive_packages
+tlmgr install $(sed 's/\s*#.*//;/^\s*$/d' texlive/texlive_packages)
 
 # Keep no backups (not required, simply makes cache bigger)
 tlmgr option -- autobackup 0

--- a/4-texlive/texlive/texlive_packages
+++ b/4-texlive/texlive/texlive_packages
@@ -1,4 +1,5 @@
-# In the case you have to install LaTeX packages manually, you can check https://www.ctan.org/pkg/some-package to see in which TeX Live package it is contained,
+# In the case you have to install LaTeX packages manually, you can check 
+# https://www.ctan.org/pkg/some-package to see in which TeX Live package it is contained,
 # or use tlmgr info some-package
 
 # Base tools to compile
@@ -7,7 +8,7 @@ texliveonfly latexmk
 # Collections
 collection-langeuropean
 collection-fontsrecommended
-collection-fontsrecommended
+
 # LuaTeX
 luaotfload
 


### PR DESCRIPTION
A couple of notes here, it's best to create the package list locally and then try on `travis`, although `texliveonfly` does a great job, the cache expires every 28 days and this slows down the process of compiling files if you don't have an updated cache.

I have added some notes for the use of gs for users who still use `latex>dvips>ps2pdf` or who use images in `.eps` format (if ...there are still some `pstricks/epstopdf` users)