### PR TITLE
[setup-tectonic] Simpify tectonic cache path

### DIFF
--- a/.github/workflows/setup-tectonic-action.yml
+++ b/.github/workflows/setup-tectonic-action.yml
@@ -11,14 +11,12 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - name: Export Tectonic cache path
-        run: echo TECTONIC_CACHE_PATH=$HOME/.cache/Tectonic >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v2
       - uses: actions/cache@v2
         name: Tectonic Cache
         with:
-          path: ${{ env.TECTONIC_CACHE_PATH }}
+          path: ~/.cache/Tectonic
           key: ${{ runner.os }}-tectonic-${{ hashFiles('**/*.tex') }}
           restore-keys: |
             ${{ runner.os }}-tectonic-


### PR DESCRIPTION
I just figured out that in ubuntu/mac based runners you can simplify the cache step (eg omit setting the environment variable). 